### PR TITLE
zipkin was missing from builtin modules so add

### DIFF
--- a/kong-plugin-zipkin-0.1.0-1.rockspec
+++ b/kong-plugin-zipkin-0.1.0-1.rockspec
@@ -27,5 +27,6 @@ build = {
   modules = {
     ["kong.plugins."..pluginName..".handler"] = "kong/plugins/"..pluginName.."/handler.lua",
     ["kong.plugins."..pluginName..".schema"] = "kong/plugins/"..pluginName.."/schema.lua",
+    ["kong.plugins."..pluginName..".zipkin"] = "kong/plugins/"..pluginName.."/zipkin.lua",
   }
 }


### PR DESCRIPTION
#9 

`zipkin.lua` was missing from builtin modules.
so it raised an error of `kong.plugins.zipkin.zipkin` was not found when specify zipkin as a custom plugin of kong.

I tested on docker as follows.
```
Removing intermediate container b3635cc979b6
 ---> 6a12e1b28bcd
Step 6/12 : RUN git clone https://github.com/tetsushiawano/kong-plugin-zipkin.git $KONG_HOME/plugins/kong-plugin-zipkin &&     (cd $KONG_HOME/plugins/kong-plugin-zipkin/ && luarocks make)
 ---> Running in 03a3a6e5fcc6
Cloning into '/usr/local/share/lua/5.1/kong/plugins/kong-plugin-zipkin'...
Warning: The directory '/root/.cache/luarocks' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing /usr/local/bin/luarocks with sudo, you may want sudo's -H flag.
kong-plugin-zipkin 0.1.0-1 is now installed in /usr/local (license: MIT)
```

And confirmed that it adds zipkin to kong succesfully.
<img width="327" alt="screen shot 2018-06-08 at 23 00 54" src="https://user-images.githubusercontent.com/24989207/41162110-e7ffce3e-6b6f-11e8-8f97-10b6392b9be6.png">

